### PR TITLE
Ensure /var/lib/puppet is owned by user puppet

### DIFF
--- a/scripts/puppetserver.sh
+++ b/scripts/puppetserver.sh
@@ -13,7 +13,7 @@ SERVICE_STOP_RETRIES=60
 /usr/bin/install --directory --owner=puppet --group=puppet --mode=775 /var/run/puppetlabs/puppetserver
 
 # set ownership on var directory
-chown puppet /var/lib/puppet
+chown -R puppet:puppet /var/lib/puppet/
 
 # copied from SystemD unit provided by puppet server
 exec sudo -u puppet -H /usr/bin/java $JAVA_ARGS '-XX:OnOutOfMemoryError=kill -9 %%p' -Djava.security.egd=/dev/urandom \

--- a/scripts/puppetserver.sh
+++ b/scripts/puppetserver.sh
@@ -12,6 +12,9 @@ SERVICE_STOP_RETRIES=60
 # ExecStartPre
 /usr/bin/install --directory --owner=puppet --group=puppet --mode=775 /var/run/puppetlabs/puppetserver
 
+# set ownership on var directory
+chown puppet /var/lib/puppet
+
 # copied from SystemD unit provided by puppet server
 exec sudo -u puppet -H /usr/bin/java $JAVA_ARGS '-XX:OnOutOfMemoryError=kill -9 %%p' -Djava.security.egd=/dev/urandom \
     -cp "${INSTALL_DIR}/puppet-server-release.jar" clojure.main \


### PR DESCRIPTION
If /var/lib/puppet is a host volume, by default it will be owned by root, and puppetserver will fail to start.
